### PR TITLE
tableの開閉を実装

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -21,3 +21,15 @@ border-radius: 10px;
     border-radius: 0px;
     background-color: transparent;
 }
+
+.toggle-trigger {
+    color: black;
+}
+
+.toggle-target tr:nth-child(n+6) {
+    display: none;
+}
+
+.toggle-target.toggle-open tr:nth-child(n+6) {
+    display: table-row;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,3 +24,20 @@ TOP PAGE
 </a>
 </h3>
 </div>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script>
+$(function() {
+    $('.toggle-trigger').on('click', function() {
+        const target = $(this).attr('href');
+        if ($(target).hasClass('toggle-open')) {
+            $(target).removeClass('toggle-open');
+            $(this).text('すべて表示');
+        } else {
+            $(target).addClass('toggle-open');
+            $(this).text('上位5名を表示');
+        }
+    });
+});
+</script>
+</body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,8 +25,8 @@
 <a href="leaderboard/?league={{T.leagueinfo.league}}">
 <img src="{% static 'icon.png' %}" style="height:30px;width:30px">
 </a></h3>
-<div style="background-color:{{T.leagueinfo.bgcolor}};padding:50px;border-radius:20px">
-<table>
+<div id="{{T.leagueinfo.league}}" class="toggle-target" style="background-color:{{T.leagueinfo.bgcolor}};padding:50px;border-radius:20px">
+<table class="table table-striped table-borderless">
 <thead style="color:{{T.leagueinfo.fontcolor}}">
 <tr><th>プレイヤー名</th><th>Top3PP</th><th>ひとこと</th></tr>
 </thead>
@@ -46,6 +46,9 @@
 {% endfor %}
 </tbody>
 </table>
+{% if T.players|length > 5 %}
+<a class="toggle-trigger" href="#{{T.leagueinfo.league}}">すべて表示</a>
+{% endif %}
 </div>
 {% endfor %}
 


### PR DESCRIPTION
### 概要
tableを開閉できる機能を実装。
base.htmlに実装を置いたのでどこのページからでも呼び出せる
※TODO: コード分量増えたらjsファイルに分離

ついでにtableの視認性を上げるためにbootstrapのclass指定を追加。

### 使い方
1. 開閉したいtableの直上のdivタグに `class="toggle-target"` を指定する
2. 同divタグにidを指定する
3. tableと同階層に開閉用のaタグを設置する
4. 同aタグに `class="toggle-trigger"` を指定、hrefに2.で指定したidを指定する (`<div id="hoge">` の場合 `href="#hoge"`)

### 注意点
- class指定したdiv直下にtableが複数あると正しく動作しない
- 参考実装はTOPページの参加者リストに適用してるので、実際に使う場合は必要な箇所に適用する必要あり

### 心残り
- 透過グラデーションを使って続きが隠れてる感を出したかったが、それに合ったボタンを置けるデザインセンスが無かった