### PR TITLE
Bootstrapのtooltipを追加

### DIFF
--- a/static/jbsl2.js
+++ b/static/jbsl2.js
@@ -1,4 +1,5 @@
 $(function() {
+    // define event handler
     $('.top5-trigger').on('click', function() {
         const target = $(this).attr('href');
         if ($(target).hasClass('top5-open')) {
@@ -30,5 +31,12 @@ $(function() {
             $(target).addClass('border8-open');
             $(this).text('予選通過ラインのみ表示');
         }
+    });
+
+    // initialize
+    // https://getbootstrap.com/docs/5.1/components/tooltips/#example-enable-tooltips-everywhere
+    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl);
     });
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <head>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 <link rel="stylesheet" href="{% static 'style.css' %}">
 <title>
 JBSL info
@@ -30,7 +30,7 @@ Top Page
 </h3>
 </div>
 
-
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 <script src="{% static 'jbsl2.js' %}"></script>
 </body>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -52,32 +52,41 @@
 {% if s.player.abstein %}（棄権）{% endif %}
 </td>
 <td width="70px">
-<span class="c-tooltip" data-tooltip=
-"
+<span
+{% if s.count_maps %}
+data-bs-toggle="tooltip" data-bs-placement="right" data-bs-html="true" title="
 {% for c in s.count_maps %}
-{{c.map.title | truncatechars:10}}({{c.pos}}), 
+{{c.map.title | truncatechars:20}} ({{c.pos}})<br>
 {% endfor %}
-">
+"
+{% endif %}
+>
 {{s.pos}}
 </span>
 </td>
 <td width="70px">
-<span class="c-tooltip" data-tooltip=
-"
+<span
+{% if s.count_maps %}
+data-bs-toggle="tooltip" data-bs-placement="right" data-bs-html="true" title="
 {% for c in s.count_maps %}
-{{c.map.title | truncatechars:20}}, 
+{{c.map.title | truncatechars:25}}<br>
 {% endfor %}
-">
+"
+{% endif %}
+>
 {{s.valid}}
 </span>
 </td>
 <td width="70px">
-<span class="c-tooltip" data-tooltip=
-"
+<span
+{% if s.count_maps %}
+data-bs-toggle="tooltip" data-bs-placement="right" data-bs-html="true" title="
 {% for c in s.count_maps %}
-{{c.map.title | truncatechars:10}}({{c.acc}}), 
+{{c.map.title | truncatechars:15}} ({{c.acc}})<br>
 {% endfor %}
-">
+"
+{% endif %}
+>
 {{s.acc|floatformat:2}}
 </span>
 </td>


### PR DESCRIPTION
Bootstrapの機能を使ってリーダーボードのtooltipを実装
https://getbootstrap.com/docs/5.1/components/tooltips/

5.0.0-beta だとmousehoverを繰り返すと表示されなくなる不具合があったため、Bootstrapのバージョンを5.1.3に上げました。